### PR TITLE
Fix Profile.intersection pointing to an incorrect list

### DIFF
--- a/lib/profile.js
+++ b/lib/profile.js
@@ -78,7 +78,7 @@ Profile.prototype.intersection = function(other){
         if(listi === listj){
             i += 1;
             j += 1;
-        }else if(listi < listj){
+        }else if(listi.length < listj.length){
             i += 1;
         }else{
             j += 1;

--- a/lib/profile.js
+++ b/lib/profile.js
@@ -74,7 +74,7 @@ Profile.prototype.intersection = function(other){
     while(i < self.list.length && j < other.list.length){
         intersect += self.gram_edit_distance(self.list[i], other.list[j]);
         var listi = self.list[i].join();
-        var listj = self.list[j].join();
+        var listj = other.list[j].join();
         if(listi === listj){
             i += 1;
             j += 1;


### PR DESCRIPTION
Hi.
Thanks for a nice lib!

According to the core referenced below, `Profile.intersection` should get `other.list[j]` instead of `self.list[j]`.
This also caused unexpected behavior where single line difference made two functions have up to 0.9 edit distance.

https://github.com/TylerGoeringer/PyGram/blob/master/src/PyGram.py#L58-L74